### PR TITLE
Create place view. Add lat/long support to frontend/backend.

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -47,8 +47,6 @@
 // Import Bulma's core
 @import "~bulma/sass/utilities/_all";
 
-// Set your colors
-// $primary: #43aa8b;
 $primary: #db504a;
 $primary-invert: findColorInvert($primary);
 $twitter: #4099FF;

--- a/client/src/components/SearchBar.vue
+++ b/client/src/components/SearchBar.vue
@@ -41,7 +41,7 @@ export default class SearchBar extends Vue {
   }
 
   editPlace() {
-    this.$router.push('edit');
+    this.$router.push({ name: 'edit_place' });
   }
 
   search() {

--- a/client/src/components/SearchListItem.vue
+++ b/client/src/components/SearchListItem.vue
@@ -10,7 +10,9 @@
         <div class="content">
             <div class="columns is-gapless is-multiline">
               <div class="column is-half">
-                <strong style="color:#8d6b94;">{{place.placeName}}</strong>
+                <router-link :to="{ name: 'view_place', params: { id: place.placeId } }">
+                  <strong class="placeName">{{place.placeName}}</strong>
+                </router-link>
               </div>
               <div class="column is-half">
                 <b-rate class="is-pulled-right"
@@ -30,7 +32,10 @@
             </p>
           </div>
           <div class="level-right">
-            <router-link class="level-item" :to="{ name: 'edit', params: { id: place.placeId } }">
+            <router-link
+              class="level-item"
+              :to="{ name: 'edit_place', params: { id: place.placeId } }"
+            >
               <span class="icon is-small"><i class="fas fa-edit"></i></span>
             </router-link>
           </div>
@@ -57,5 +62,13 @@ export default class EditPlace extends Vue {
 <style lang="scss" scoped>
 small {
   color: #777777;
+}
+
+.placeName {
+  color: #8d6b94;
+}
+
+.placeName:hover {
+  color: #db504a;
 }
 </style>

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -19,10 +19,16 @@ const routes = [
     component: () => import(/* webpackChunkName: "about" */ '../views/About.vue'),
   },
   {
-    path: '/edit/:id?',
-    name: 'edit',
+    path: '/place/edit/:id?',
+    name: 'edit_place',
     props: true,
-    component: () => import(/* webpackChunkName: "edit" */ '../views/EditPlace.vue'),
+    component: () => import(/* webpackChunkName: "edit_place" */ '../views/EditPlace.vue'),
+  },
+  {
+    path: '/place/:id?',
+    name: 'view_place',
+    props: true,
+    component: () => import(/* webpackChunkName: "view_place" */ '../views/ViewPlace.vue'),
   },
 ];
 

--- a/client/src/store/modules/app.ts
+++ b/client/src/store/modules/app.ts
@@ -24,7 +24,8 @@ class App extends VuexModule implements IAppState {
             email: response.data.email,
             placeName: response.data.place_name,
             address: response.data.address,
-            latLong: response.data.lat_long,
+            latitude: response.data.latitude,
+            longitude: response.data.longitude,
             avgRating: response.data.avg_rating,
             description: response.data.description,
           };

--- a/client/src/types/Place.ts
+++ b/client/src/types/Place.ts
@@ -3,7 +3,8 @@ interface Place {
     placeName: string;
     email: string;
     address: string;
-    latLong: string;
+    latitude: number;
+    longitude: number;
     avgRating: number;
     description: string;
 }

--- a/client/src/views/EditPlace.vue
+++ b/client/src/views/EditPlace.vue
@@ -87,15 +87,7 @@ export default class EditPlace extends Vue {
 
   isLoading: boolean = false;
 
-  place: Place = {
-    placeId: -1,
-    placeName: '',
-    email: '',
-    address: '',
-    latLong: '',
-    avgRating: 0,
-    description: '',
-  }
+  place: Place = {} as any;
 
   public save(): void {
     this.saving = true;
@@ -172,7 +164,8 @@ export default class EditPlace extends Vue {
           this.place.placeName = response.data.place_name;
           this.place.email = response.data.email;
           this.place.address = response.data.address;
-          this.place.latLong = response.data.lat_long;
+          this.place.latitude = response.data.latitude;
+          this.place.longitude = response.data.longitude;
           this.place.avgRating = response.data.avg_rating;
           this.place.description = response.data.description;
           this.isLoading = false;

--- a/client/src/views/ViewPlace.vue
+++ b/client/src/views/ViewPlace.vue
@@ -1,0 +1,85 @@
+<template>
+  <section>
+    <div class="container">
+      <div class="box viewPlace">
+        <div class="columns is-multiline">
+          <div class="column is-full">
+            <h1>Map</h1> <!--Insert the map here for Google Maps-->
+          </div>
+          <div class="column is-one-quarter">
+            <h2 class="has-text-weight-bold is-size-5">{{ place.placeName }}</h2>
+            <p class="has-text-weight-bold is-size-6">Address:</p>
+            <p>{{ place.address }}</p>
+            <p class="has-text-weight-bold is-size-6">Lat/Long:</p>
+            <small>{{ place.latitude }}, {{ place.longitude }}</small>
+          </div>
+          <div class="column">
+            <h2 class="has-text-weight-bold is-size-5">Description</h2>
+            <p>{{ place.description }}</p>
+          </div>
+        </div>
+      </div>
+      <div class="box viewPlace">
+        <h2 class="has-text-weight-bold is-size-5">Reviews</h2>
+        <article class="media">
+          <div class="media-content">
+            <div class="content">
+              <p>
+                <strong>John Smith</strong> <small>@johnsmith</small>
+                <br>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                Proin ornare magna eros, eu pellentesque tortor vestibulum ut.
+                Maecenas non massa sem. Etiam finibus odio quis feugiat facilisis.
+              </p>
+            </div>
+          </div>
+        </article>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import Place from '@/types/Place';
+import httpClient from '@/services/api';
+
+@Component({
+  props: {
+    id: Number,
+  },
+})
+export default class ViewPlace extends Vue {
+  @Prop(Number) readonly id: number | undefined;
+
+  isLoading: boolean = false;
+
+  place: Place = {} as any;
+
+  created() {
+    if (this.id) {
+      this.isLoading = true;
+      httpClient.get(`/place/${this.id}`)
+        .then((response) => {
+          this.place = {
+            placeId: response.data.place_id,
+            placeName: response.data.place_name,
+            email: response.data.email,
+            address: response.data.address,
+            latitude: response.data.latitude,
+            longitude: response.data.longitude,
+            avgRating: response.data.avg_rating,
+            description: response.data.description,
+          };
+          this.isLoading = false;
+        });
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.viewPlace {
+  margin-top: 25px;
+}
+</style>

--- a/server/chalicelib/place.py
+++ b/server/chalicelib/place.py
@@ -28,14 +28,12 @@ def post_place(request, conn):
     place_name = json["place_name"]
     address = json["address"]
     description = json["description"]
-    if "latitude" in json and "longitude" in json:
-        lat_long = f"{json['latitude']} {json['longitude']}"
-    else:
-        lat_long = None
+    latitude = json["latitude"] if "latitude" in json else None
+    longitude = json["longitude"] if "longitude" in json else None
     try:
         with conn.cursor() as cursor:
-            query = "INSERT INTO Place (email, place_name, address, lat_long, avg_rating, description) VALUES (%s, %s, %s, %s, %s, %s)"
-            cursor.execute(query, (email, place_name, address, lat_long, 0, description))
+            query = "INSERT INTO Place (email, place_name, address, latitude, longitude, avg_rating, description) VALUES (%s, %s, %s, %s, %s, %s, %s)"
+            cursor.execute(query, (email, place_name, address, latitude, longitude, 0, description))
             conn.commit()
             return Response("")
     finally:
@@ -43,9 +41,7 @@ def post_place(request, conn):
 
 def patch_place(id, request, conn):
     json = request.json_body
-    UPDATEABLE = set(["place_name", "address", "description", "lat_long"])
-    if "latitude" in json and "longitude" in json:
-        json["lat_long"] = f"{json['latitude']} {json['longitude']}"
+    UPDATEABLE = set(["place_name", "address", "description", "latitude", "longitude"])
     try:
         with conn.cursor() as cursor:
             for k, v in json.items():


### PR DESCRIPTION
Added:

- Temporary Place view. User can click on item in search list and view the full information including a list of reviews and the location of the area.
  - This is temporarily blocked until reviews and Google Maps support is added.

Modified:

- Edited Place interface to support separate latitude and longitude values
- Edited backend to allow PATCH of latitude and longitude.

This isn't completely finished, but I figured it should be pushed out since it includes some changes to support separate latitude and longitude. Also it may be helpful when adding google maps support to have a good place to test it out for a single location.